### PR TITLE
Fix junit-benchmarks test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,11 @@ Wisconsin-Madison.</license.copyrightOwners>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>junit-benchmarks</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>net.imagej</groupId>
 			<artifactId>imagej-ops</artifactId>
 			<exclusions>


### PR DESCRIPTION
This should fix the [travis CI build](https://travis-ci.org/imagej/imagej-server/builds/216398813).