### PR TITLE
updateJquery: update jquery node package

### DIFF
--- a/clients/webNew/package-lock.json
+++ b/clients/webNew/package-lock.json
@@ -5404,9 +5404,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.9.1.tgz",
-      "integrity": "sha1-5M1INfqu+63lNYV2E8D8P/KtrzQ="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.0.0.tgz",
+      "integrity": "sha1-laKpVBKRqfgZ4Bb4W6JHEW0D5Ks="
     },
     "js-base64": {
       "version": "2.4.3",

--- a/clients/webNew/package.json
+++ b/clients/webNew/package.json
@@ -27,7 +27,7 @@
     "bootstrap": "^4.1.1",
     "core-js": "^2.5.6",
     "hoek": "^4.2.1",
-    "jquery": "^1.9.1",
+    "jquery": "^3.0.0",
     "ngx-bootstrap": "^2.0.5",
     "npm": "^5.10.0",
     "popper.js": "^1.14.3",


### PR DESCRIPTION
Following the previous node.js pull request ([link](https://github.com/imagej/imagej-server/pull/23)), the jquery package has been deemed as vulnerable.

This PR fixes it by updating its version.