### PR TITLE
Fix undesired object registration

### DIFF
--- a/src/main/java/net/imagej/server/WebCommandInfo.java
+++ b/src/main/java/net/imagej/server/WebCommandInfo.java
@@ -30,16 +30,19 @@ public class WebCommandInfo extends CommandInfo {
 						.getField());
 				final String name = input.getName();
 
+				final boolean isResolved = relatedModule.isInputResolved(name);
+
 				// Include resolved status in the JSON feed.
 				// This is handy for judiciously overwriting already-resolved inputs,
 				// particularly the "active image" inputs, which will be reported as
 				// resolved, but not necessarily match what's selected on the client
 				// side.
-				webCommandModuleItem.isResolved = relatedModule.isInputResolved(name);
+				webCommandModuleItem.isResolved = isResolved;
 
-				// Include startingValue in the JSON feed.
-				// Useful for populating the dialog!
-				webCommandModuleItem.startingValue = relatedModule.getInput(name);
+				// If the input is not resolved, include startingValue in the JSON feed.
+				// This is useful for populating the dialog.
+				webCommandModuleItem.startingValue = (!isResolved) ? relatedModule
+					.getInput(name) : null;
 
 				checkedInputs.add(webCommandModuleItem);
 			}

--- a/src/main/java/net/imagej/server/WebCommandInfo.java
+++ b/src/main/java/net/imagej/server/WebCommandInfo.java
@@ -1,3 +1,4 @@
+
 package net.imagej.server;
 
 import java.util.ArrayList;
@@ -24,13 +25,16 @@ public class WebCommandInfo extends CommandInfo {
 		final List<WebCommandModuleItem<?>> checkedInputs = new ArrayList<>();
 		for (final ModuleItem<?> input : super.inputs()) {
 			if (input instanceof CommandModuleItem) {
-				WebCommandModuleItem<?> webCommandModuleItem = new WebCommandModuleItem<>(this, (CommandModuleItem<?>)input);
+				final WebCommandModuleItem<Object> webCommandModuleItem =
+					new WebCommandModuleItem<>(this, ((CommandModuleItem<?>) input)
+						.getField());
 				final String name = input.getName();
 
 				// Include resolved status in the JSON feed.
 				// This is handy for judiciously overwriting already-resolved inputs,
 				// particularly the "active image" inputs, which will be reported as
-				// resolved, but not necessarily match what's selected on the client side.
+				// resolved, but not necessarily match what's selected on the client
+				// side.
 				webCommandModuleItem.isResolved = relatedModule.isInputResolved(name);
 
 				// Include startingValue in the JSON feed.

--- a/src/main/java/net/imagej/server/WebCommandModuleItem.java
+++ b/src/main/java/net/imagej/server/WebCommandModuleItem.java
@@ -1,4 +1,7 @@
+
 package net.imagej.server;
+
+import java.lang.reflect.Field;
 
 import org.scijava.command.CommandInfo;
 import org.scijava.command.CommandModuleItem;
@@ -6,9 +9,11 @@ import org.scijava.command.CommandModuleItem;
 public class WebCommandModuleItem<T> extends CommandModuleItem<T> {
 
 	public boolean isResolved;
-	public Object startingValue;
+	public T startingValue;
 
-	public WebCommandModuleItem (CommandInfo commandInfo, CommandModuleItem<T> commandModuleItem) {
-		super(commandInfo, commandModuleItem.getField());
+	public WebCommandModuleItem(final CommandInfo commandInfo,
+		final Field field)
+	{
+		super(commandInfo, field);
 	}
 }


### PR DESCRIPTION
After the recent update, "ghost" objects started to appear on the server. Investigations have shown that these were serialized `startingValue` objects from the resolved inputs of a given module and were registered by the `DefaultObjectService` upon the module information retrieval.